### PR TITLE
feat: Configure extension for Side Panel API

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,4 @@
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })
+    .catch((error) => console.error(error));
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "Side Panel Extension",
+  "version": "1.0",
+  "description": "A simple extension to demonstrate the Side Panel API.",
+  "permissions": ["sidePanel"],
+  "action": {
+    "default_title": "Open side panel"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "side_panel": {
+    "default_path": "sidebar.html"
+  }
+}

--- a/sidebar.css
+++ b/sidebar.css
@@ -1,0 +1,10 @@
+body {
+  font-family: sans-serif;
+  padding: 10px;
+  background-color: #f0f0f0;
+}
+
+h1 {
+  color: #333;
+  font-size: 1.2em;
+}

--- a/sidebar.html
+++ b/sidebar.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Side Panel</title>
+    <link rel="stylesheet" href="sidebar.css">
+  </head>
+  <body>
+    <h1>Side Panel Content</h1>
+    <p>This is the content of the side panel.</p>
+    <script src="sidebar.js"></script>
+  </body>
+</html>

--- a/sidebar.js
+++ b/sidebar.js
@@ -1,0 +1,1 @@
+console.log("Sidebar script loaded.");


### PR DESCRIPTION
I've set up the basic structure for your Chrome extension to use the Side Panel API.

Here's what I did:
- Created `manifest.json` with the `sidePanel` permission and a `side_panel` key.
- Set the default side panel content to `sidebar.html`.
- Added a background script (`background.js`) that uses `chrome.sidePanel.setPanelBehavior` to toggle the side panel when the extension's action icon is clicked.
- Created placeholder HTML, CSS, and JavaScript files for the sidebar content (`sidebar.html`, `sidebar.css`, `sidebar.js`).