### PR TITLE
feat: Implement tab visibility functions

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,3 +2,28 @@ chrome.runtime.onInstalled.addListener(() => {
   chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })
     .catch((error) => console.error(error));
 });
+
+const HIDDEN_GROUP_TITLE = "Inactive Workspaces";
+
+async function hideTabs(tabIds) {
+  try {
+    const [hiddenGroup] = await chrome.tabGroups.query({ title: HIDDEN_GROUP_TITLE });
+
+    if (hiddenGroup) {
+      await chrome.tabs.group({ tabIds, groupId: hiddenGroup.id });
+    } else {
+      const newGroupId = await chrome.tabs.group({ tabIds });
+      await chrome.tabGroups.update(newGroupId, { title: HIDDEN_GROUP_TITLE, collapsed: true });
+    }
+  } catch (error) {
+    console.error("Error hiding tabs:", error);
+  }
+}
+
+async function showTabs(tabIds) {
+  try {
+    await chrome.tabs.ungroup(tabIds);
+  } catch (error) {
+    console.error("Error showing tabs:", error);
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Side Panel Extension",
   "version": "1.0",
   "description": "A simple extension to demonstrate the Side Panel API.",
-  "permissions": ["sidePanel"],
+  "permissions": ["sidePanel", "tabGroups", "tabs", "storage"],
   "action": {
     "default_title": "Open side panel"
   },


### PR DESCRIPTION
This commit introduces the core functions for managing tab visibility by showing and hiding them based on the active workspace.

- The `hideTabs` function moves a given set of tabs into a special, collapsed tab group titled "Inactive Workspaces". If the group doesn't exist, it's created.
- The `showTabs` function removes a given set of tabs from any group they are in, making them visible again.
- The `manifest.json` file has been updated to include the necessary `tabs` and `tabGroups` permissions required for this functionality.