### PR TITLE
feat: Implement tab management for workspaces

### DIFF
--- a/background.js
+++ b/background.js
@@ -5,25 +5,71 @@ chrome.runtime.onInstalled.addListener(() => {
 
 const HIDDEN_GROUP_TITLE = "Inactive Workspaces";
 
-async function hideTabs(tabIds) {
-  try {
-    const [hiddenGroup] = await chrome.tabGroups.query({ title: HIDDEN_GROUP_TITLE });
+const HIDDEN_GROUP_ID_KEY = "hiddenGroupId";
 
-    if (hiddenGroup) {
-      await chrome.tabs.group({ tabIds, groupId: hiddenGroup.id });
-    } else {
+async function hideTabs(tabIds) {
+  if (!tabIds || tabIds.length === 0) return;
+
+  try {
+    const data = await chrome.storage.local.get(HIDDEN_GROUP_ID_KEY);
+    let groupId = data[HIDDEN_GROUP_ID_KEY];
+
+    // If a group ID exists, check if the group is still valid
+    if (groupId) {
+      try {
+        await chrome.tabGroups.get(groupId);
+      } catch (error) {
+        // The group doesn't exist anymore, so we'll create a new one.
+        groupId = null;
+        await chrome.storage.local.remove(HIDDEN_GROUP_ID_KEY);
+      }
+    }
+
+    // If no valid group ID, create a new group
+    if (!groupId) {
       const newGroupId = await chrome.tabs.group({ tabIds });
-      await chrome.tabGroups.update(newGroupId, { title: HIDDEN_GROUP_TITLE, collapsed: true });
+      await chrome.tabGroups.update(newGroupId, {
+        title: HIDDEN_GROUP_TITLE,
+        collapsed: true,
+      });
+      await chrome.storage.local.set({ [HIDDEN_GROUP_ID_KEY]: newGroupId });
+    } else {
+      await chrome.tabs.group({ tabIds, groupId });
     }
   } catch (error) {
-    console.error("Error hiding tabs:", error);
+    // A common error is trying to group a tab that is already in a group.
+    // We can ungroup them first and then regroup them.
+    if (error.message.includes("Tabs cannot be in the same group more than once")) {
+        console.warn("Some tabs were already in the hidden group. This is expected.");
+    } else if (error.message.includes("No current window")) {
+        console.warn("Cannot hide tabs without a window focus.");
+    }
+    else {
+      console.error("Error hiding tabs:", error);
+    }
   }
 }
 
 async function showTabs(tabIds) {
+  if (!tabIds || tabIds.length === 0) return;
   try {
     await chrome.tabs.ungroup(tabIds);
   } catch (error) {
-    console.error("Error showing tabs:", error);
+    // This can happen if the tabs are not in any group, which is fine.
+    if (error.message.includes("No tab group with id")) {
+        console.warn("Tried to ungroup tabs that were not in a group.");
+    } else {
+        console.error("Error showing tabs:", error);
+    }
   }
 }
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === 'hideTabs') {
+    hideTabs(request.tabIds);
+  } else if (request.action === 'showTabs') {
+    showTabs(request.tabIds);
+  }
+  // To indicate that we will respond asynchronously.
+  return true;
+});

--- a/sidebar.css
+++ b/sidebar.css
@@ -29,6 +29,31 @@ body {
     align-items: center;
     justify-content: center;
     font-weight: bold;
+    cursor: pointer;
+    border: 2px solid transparent;
+}
+
+.workspace-icon.active {
+    border-color: #007bff;
+}
+
+.sidebar-controls {
+    padding: 10px;
+    border-bottom: 1px solid #ddd;
+}
+
+.add-tab-btn {
+    width: 100%;
+    padding: 10px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.add-tab-btn:hover {
+    background-color: #0056b3;
 }
 
 .create-workspace-btn {

--- a/sidebar.html
+++ b/sidebar.html
@@ -11,6 +11,9 @@
         <div class="workspace-list">
             <!-- Workspace icons will go here -->
         </div>
+        <div class="sidebar-controls">
+            <button class="add-tab-btn">Add Current Tab</button>
+        </div>
         <div class="tab-list">
             <!-- Tabs for the active workspace will go here -->
         </div>

--- a/sidebar.js
+++ b/sidebar.js
@@ -1,38 +1,146 @@
 document.addEventListener('DOMContentLoaded', function() {
     const createWorkspaceBtn = document.querySelector('.create-workspace-btn');
+    const addTabBtn = document.querySelector('.add-tab-btn');
     const workspaceList = document.querySelector('.workspace-list');
+    const tabList = document.querySelector('.tab-list');
 
-    function renderWorkspaces() {
-        chrome.storage.local.get({workspaces: []}, function(data) {
-            const workspaces = data.workspaces;
-            workspaceList.innerHTML = ''; // Clear existing workspaces
-            workspaces.forEach(workspace => {
-                const workspaceEl = document.createElement('div');
-                workspaceEl.className = 'workspace-icon';
-                workspaceEl.textContent = workspace.name.charAt(0).toUpperCase();
-                workspaceEl.title = workspace.name;
-                workspaceList.appendChild(workspaceEl);
-            });
+    const ACTIVE_WORKSPACE_ID_KEY = 'activeWorkspaceId';
+
+    async function renderWorkspaces() {
+        const { workspaces = [] } = await chrome.storage.local.get({ workspaces: [] });
+        const { [ACTIVE_WORKSPACE_ID_KEY]: activeWorkspaceId } = await chrome.storage.local.get(ACTIVE_WORKSPACE_ID_KEY);
+
+        workspaceList.innerHTML = ''; // Clear existing workspaces
+        workspaces.forEach(workspace => {
+            const workspaceEl = document.createElement('div');
+            workspaceEl.className = 'workspace-icon';
+            workspaceEl.textContent = workspace.name.charAt(0).toUpperCase();
+            workspaceEl.title = workspace.name;
+            workspaceEl.dataset.workspaceId = workspace.id;
+
+            if (workspace.id === activeWorkspaceId) {
+                workspaceEl.classList.add('active');
+            }
+
+            workspaceEl.addEventListener('click', handleWorkspaceClick);
+            workspaceList.appendChild(workspaceEl);
         });
+
+        renderTabsForActiveWorkspace();
     }
 
-    renderWorkspaces();
+    async function renderTabsForActiveWorkspace() {
+        const { workspaces = [] } = await chrome.storage.local.get({ workspaces: [] });
+        const { [ACTIVE_WORKSPACE_ID_KEY]: activeWorkspaceId } = await chrome.storage.local.get(ACTIVE_WORKSPACE_ID_KEY);
+
+        tabList.innerHTML = '';
+
+        const activeWorkspace = workspaces.find(w => w.id === activeWorkspaceId);
+
+        if (activeWorkspace && activeWorkspace.tabs.length > 0) {
+            const tabsInfo = await chrome.tabs.get(activeWorkspace.tabs.filter(t => typeof t === 'number'));
+            tabsInfo.forEach(tab => {
+                const tabEl = document.createElement('div');
+                tabEl.className = 'tab-item';
+                tabEl.textContent = tab.title;
+                tabEl.title = tab.title;
+                tabEl.dataset.tabId = tab.id;
+                tabEl.addEventListener('click', () => {
+                    chrome.tabs.update(tab.id, { active: true });
+                    chrome.windows.update(tab.windowId, { focused: true });
+                });
+                tabList.appendChild(tabEl);
+            });
+        } else {
+            tabList.innerHTML = '<div class="tab-item">No tabs in this workspace yet.</div>';
+        }
+    }
+
+    function handleWorkspaceClick(event) {
+        const workspaceId = event.target.dataset.workspaceId;
+        activateWorkspace(workspaceId);
+    }
+
+    async function activateWorkspace(workspaceId) {
+        await chrome.storage.local.set({ [ACTIVE_WORKSPACE_ID_KEY]: workspaceId });
+
+        const { workspaces = [] } = await chrome.storage.local.get({ workspaces: [] });
+
+        const tabsToShow = [];
+        const tabsToHide = [];
+
+        for (const workspace of workspaces) {
+            // Ensure tabs array exists and is an array
+            const workspaceTabs = Array.isArray(workspace.tabs) ? workspace.tabs : [];
+            if (workspace.id === workspaceId) {
+                tabsToShow.push(...workspaceTabs);
+            } else {
+                tabsToHide.push(...workspaceTabs);
+            }
+        }
+
+        chrome.runtime.sendMessage({ action: 'showTabs', tabIds: tabsToShow });
+        chrome.runtime.sendMessage({ action: 'hideTabs', tabIds: tabsToHide });
+
+        renderWorkspaces();
+    }
+
+    async function addCurrentTabToActiveWorkspace() {
+        const [currentTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        const { [ACTIVE_WORKSPACE_ID_KEY]: activeWorkspaceId } = await chrome.storage.local.get(ACTIVE_WORKSPACE_ID_KEY);
+
+        if (!activeWorkspaceId) {
+            alert('Please select a workspace first!');
+            return;
+        }
+
+        if (!currentTab) {
+            alert('No active tab found.');
+            return;
+        }
+
+        const { workspaces = [] } = await chrome.storage.local.get({ workspaces: [] });
+        const activeWorkspace = workspaces.find(w => w.id === activeWorkspaceId);
+
+        if (activeWorkspace) {
+            // Ensure tabs array exists
+            if (!Array.isArray(activeWorkspace.tabs)) {
+                activeWorkspace.tabs = [];
+            }
+            // Add tab if it's not already there
+            if (!activeWorkspace.tabs.includes(currentTab.id)) {
+                activeWorkspace.tabs.push(currentTab.id);
+                await chrome.storage.local.set({ workspaces });
+                renderTabsForActiveWorkspace();
+            } else {
+                alert('This tab is already in the active workspace.');
+            }
+        }
+    }
 
     createWorkspaceBtn.addEventListener('click', function() {
         const workspaceName = prompt('Enter a name for the new workspace:');
         if (workspaceName) {
-            chrome.storage.local.get({workspaces: []}, function(data) {
+            chrome.storage.local.get({ workspaces: [] }, function(data) {
                 const workspaces = data.workspaces;
                 const newWorkspace = {
                     id: 'workspace-' + Date.now(),
                     name: workspaceName,
-                    tabs: []
+                    tabs: [] // array of tab IDs
                 };
                 workspaces.push(newWorkspace);
-                chrome.storage.local.set({workspaces: workspaces}, function() {
-                    renderWorkspaces();
+                chrome.storage.local.set({ workspaces: workspaces }, function() {
+                    if (workspaces.length === 1) {
+                        activateWorkspace(newWorkspace.id);
+                    } else {
+                        renderWorkspaces();
+                    }
                 });
             });
         }
     });
+
+    addTabBtn.addEventListener('click', addCurrentTabToActiveWorkspace);
+
+    renderWorkspaces();
 });


### PR DESCRIPTION
This commit introduces the core functionality for workspace-based tab management. It allows you to create workspaces, add tabs to them, and switch between them, showing only the tabs relevant to the active workspace.

Key changes:
- Implemented `showTabs` and `hideTabs` functions in `background.js` using the Chrome Tab Grouping API to manage tab visibility. The `hideTabs` function is robustly designed to track the hidden tab group via its ID stored in `chrome.storage`.
- Developed the sidebar UI logic in `sidebar.js` for creating and managing workspaces.
- Added functionality to activate a workspace, which highlights it in the UI and saves its state.
- Established communication between the sidebar and the background script via message passing to trigger the show/hide logic.
- Implemented the ability for you to add the current active tab to your selected workspace and view the workspace's tabs in the sidebar.