### PR TITLE
feat: Synchronize workspace data with tab changes

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -155,5 +155,12 @@ document.addEventListener('DOMContentLoaded', function() {
 
     addTabBtn.addEventListener('click', addCurrentTabToActiveWorkspace);
 
+    // Listen for messages from the background script
+    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+        if (request.action === 'refresh') {
+            renderWorkspaces();
+        }
+    });
+
     renderWorkspaces();
 });


### PR DESCRIPTION
Implement listeners for tab creation and removal to keep workspace data in sync.

- Add `chrome.tabs.onCreated` listener in `background.js` to add new tabs to the active workspace.
- Add `chrome.tabs.onRemoved` listener in `background.js` to remove closed tabs from their workspaces.
- Implement a messaging system between the background script and the sidebar to trigger UI updates.
- The sidebar now listens for 'refresh' messages and re-renders the workspace and tab lists to reflect the changes in real-time.