### PR TITLE
I've made a couple of changes to correct the manifest and improve the…

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,8 @@
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })
-    .catch((error) => console.error(error));
-});
+// Ensure the side panel is always available to be opened on action click.
+// This is idempotent, so it's safe to call on every service worker startup.
+chrome.sidePanel
+  .setPanelBehavior({ openPanelOnActionClick: true })
+  .catch((error) => console.error(error));
 
 const HIDDEN_GROUP_TITLE = "Inactive Workspaces";
 

--- a/manifest.json
+++ b/manifest.json
@@ -12,9 +12,7 @@
     "history",
     "sessions"
   ],
-  "action": {
-    "default_title": "Open side panel"
-  },
+  "action": {},
   "background": {
     "service_worker": "background.js"
   },


### PR DESCRIPTION
… side panel behavior:

- Simplified the `action` key in `manifest.json` to an empty object to avoid potential conflicts with programmatic control.

- Moved the `sidePanel.setPanelBehavior` call in `background.js` out of the `onInstalled` listener to the top level. This ensures the action button's behavior is set every time the service worker starts, making it more robust, especially for development.