### PR TITLE
I've created a minimal version of your extension to bypass an adminis…

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -36,48 +36,48 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    function renderBookmarks(bookmarks) {
-        const grid = document.getElementById('bookmarks-grid');
-        grid.innerHTML = '';
-        if (!bookmarks || bookmarks.length === 0) {
-            grid.innerHTML = '<p class="placeholder">No recent bookmarks found.</p>';
-            return;
-        }
-        bookmarks.slice(0, 6).forEach(bookmark => { // Show up to 6 bookmarks
-            const card = document.createElement('md-elevated-card');
-            card.className = 'bookmark-card';
-            card.innerHTML = `
-                <div class="card-content">
-                    <img class="icon" src="https://www.google.com/s2/favicons?sz=32&domain=${new URL(bookmark.url).hostname}" alt="">
-                    <div class="title">${bookmark.title}</div>
-                </div>
-            `;
-            card.addEventListener('click', () => window.open(bookmark.url, '_blank'));
-            grid.appendChild(card);
-        });
-    }
+    // function renderBookmarks(bookmarks) {
+    //     const grid = document.getElementById('bookmarks-grid');
+    //     grid.innerHTML = '';
+    //     if (!bookmarks || bookmarks.length === 0) {
+    //         grid.innerHTML = '<p class="placeholder">No recent bookmarks found.</p>';
+    //         return;
+    //     }
+    //     bookmarks.slice(0, 6).forEach(bookmark => { // Show up to 6 bookmarks
+    //         const card = document.createElement('md-elevated-card');
+    //         card.className = 'bookmark-card';
+    //         card.innerHTML = `
+    //             <div class="card-content">
+    //                 <img class="icon" src="https://www.google.com/s2/favicons?sz=32&domain=${new URL(bookmark.url).hostname}" alt="">
+    //                 <div class="title">${bookmark.title}</div>
+    //             </div>
+    //         `;
+    //         card.addEventListener('click', () => window.open(bookmark.url, '_blank'));
+    //         grid.appendChild(card);
+    //     });
+    // }
 
-    function renderRecentTabs(sessions) {
-        const list = document.getElementById('recent-tabs-list');
-        list.innerHTML = '';
-        if (!sessions || sessions.length === 0) {
-            list.innerHTML = '<p class="placeholder">No recently closed tabs.</p>';
-            return;
-        }
-        sessions.slice(0, 10).forEach(session => { // Show up to 10 tabs
-            if (session.tab) {
-                const item = document.createElement('md-list-item');
-                item.headline = session.tab.title;
-                item.href = session.tab.url;
-                item.target = '_blank';
-                item.innerHTML = `
-                    <img slot="start" class="favicon" src="https://www.google.com/s2/favicons?sz=32&domain=${new URL(session.tab.url).hostname}" alt="">
-                    ${session.tab.title}
-                `;
-                list.appendChild(item);
-            }
-        });
-    }
+    // function renderRecentTabs(sessions) {
+    //     const list = document.getElementById('recent-tabs-list');
+    //     list.innerHTML = '';
+    //     if (!sessions || sessions.length === 0) {
+    //         list.innerHTML = '<p class="placeholder">No recently closed tabs.</p>';
+    //         return;
+    //     }
+    //     sessions.slice(0, 10).forEach(session => { // Show up to 10 tabs
+    //         if (session.tab) {
+    //             const item = document.createElement('md-list-item');
+    //             item.headline = session.tab.title;
+    //             item.href = session.tab.url;
+    //             item.target = '_blank';
+    //             item.innerHTML = `
+    //                 <img slot="start" class="favicon" src="https://www.google.com/s2/favicons?sz=32&domain=${new URL(session.tab.url).hostname}" alt="">
+    //                 ${session.tab.title}
+    //             `;
+    //             list.appendChild(item);
+    //         }
+    //     });
+    // }
 
 
     // --- Data Fetching Functions ---
@@ -88,27 +88,27 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    async function loadBookmarks() {
-        if (chrome.bookmarks) {
-            chrome.bookmarks.getRecent(12, (bookmarks) => {
-                renderBookmarks(bookmarks);
-            });
-        }
-    }
+    // async function loadBookmarks() {
+    //     if (chrome.bookmarks) {
+    //         chrome.bookmarks.getRecent(12, (bookmarks) => {
+    //             renderBookmarks(bookmarks);
+    //         });
+    //     }
+    // }
 
-    async function loadRecentTabs() {
-        if (chrome.sessions) {
-            chrome.sessions.getRecentlyClosed({ maxResults: 10 }, (sessions) => {
-                renderRecentTabs(sessions);
-            });
-        }
-    }
+    // async function loadRecentTabs() {
+    //     if (chrome.sessions) {
+    //         chrome.sessions.getRecentlyClosed({ maxResults: 10 }, (sessions) => {
+    //             renderRecentTabs(sessions);
+    //         });
+    //     }
+    // }
 
 
     // --- Initial Load ---
     setGreeting();
     loadWorkspaces();
-    loadBookmarks();
-    loadRecentTabs();
+    // loadBookmarks();
+    // loadRecentTabs();
 
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,16 +1,13 @@
 {
   "manifest_version": 3,
-  "name": "chrome-eazy",
+  "name": "Chrome Eazy (Dev)",
   "version": "1.0",
   "description": "A browser extension to organize your tabs into clean workspaces.",
   "permissions": [
     "sidePanel",
     "tabGroups",
     "tabs",
-    "storage",
-    "bookmarks",
-    "history",
-    "sessions"
+    "storage"
   ],
   "action": {},
   "background": {


### PR DESCRIPTION
…trator block.

It appeared the extension was being blocked by a policy, likely due to its request for sensitive permissions like `bookmarks`, `history`, and `sessions`.

To diagnose and work around this, I made the following changes:
- Removed the `bookmarks`, `history`, and `sessions` permissions from `manifest.json`.
- Disabled the features in `dashboard.js` that relied on these permissions (like Recent Bookmarks and Recently Closed Tabs) to prevent errors.
- Renamed the extension to "Chrome Eazy (Dev)" in the manifest to avoid conflicts with the original and to clarify that it's a local development version.

This should allow you to load the core functionality as an unpacked extension for development and testing, confirming that the permissions were the cause of the block.