### PR TITLE
Fix: Correctly import and initialize Material Web Components

### DIFF
--- a/sidebar.css
+++ b/sidebar.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
-
 body {
     font-family: 'Roboto', sans-serif;
     margin: 0;

--- a/sidebar.html
+++ b/sidebar.html
@@ -4,20 +4,27 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sidebar</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/material-dynamic-colors@1.1.0/dist/material-dynamic-colors.min.css">
     <link rel="stylesheet" href="sidebar.css">
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <!-- Material Symbols -->
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+    <script type="importmap">
+    {
+      "imports": {
+        "@material/web/": "https://esm.run/@material/web/"
+      }
+    }
+    </script>
     <script type="module">
-        import 'https://cdn.jsdelivr.net/npm/@material/web/button/filled-button.js';
-        import 'https://cdn.jsdelivr.net/npm/@material/web/button/outlined-button.js';
-        import 'https://cdn.jsdelivr.net/npm/@material/web/button/icon-button.js';
-        import 'https://cdn.jsdelivr.net/npm/@material/web/fab/fab.js';
-        import 'https://cdn.jsdelivr.net/npm/@material/web/list/list.js';
-        import 'https://cdn.jsdelivr.net/npm/@material/web/list/list-item.js';
-        import 'https://cdn.jsdelivr.net/npm/@material/web/dialog/dialog.js';
-        import 'https://cdn.jsdelivr.net/npm/@material/web/textfield/filled-text-field.js';
-        import 'https://cdn.jsdelivr.net/npm/@material/web/tabs/tabs.js';
-        import 'https://cdn.jsdelivr.net/npm/@material/web/tabs/primary-tab.js';
-        import 'https://cdn.jsdelivr.net/npm/@material/web/icon/icon.js';
+        import '@material/web/all.js';
+        import {
+            styles as typescaleStyles
+        } from '@material/web/typography/md-typescale-styles.js';
+
+        document.adoptedStyleSheets.push(typescaleStyles.styleSheet);
     </script>
 </head>
 <body class="dark">
@@ -32,11 +39,17 @@
                 <md-icon slot="icon">add</md-icon>
             </md-filled-button>
 
+            <md-tabs>
+                <md-primary-tab>Workspaces</md-primary-tab>
+                <md-primary-tab>Tabs</md-primary-tab>
+            </md-tabs>
+
             <md-list class="workspace-list">
                 <!-- Workspaces will be rendered here -->
             </md-list>
 
-            <md-list class="tab-list">
+            <md-list class="tab-list" style="display: none;">
+                <!-- Tabs will be rendered here -->
             </md-list>
         </div>
     </div>

--- a/sidebar.js
+++ b/sidebar.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const addTabBtn = document.getElementById('add-tab-btn');
         const workspaceList = document.querySelector('.workspace-list');
         const tabList = document.querySelector('.tab-list');
+        const tabs = document.querySelector('md-tabs');
 
         const ACTIVE_WORKSPACE_ID_KEY = 'activeWorkspaceId';
 
@@ -209,6 +210,16 @@ document.addEventListener('DOMContentLoaded', function() {
         createWorkspaceDialog.addEventListener('closed', handleCreateWorkspaceDialogClose);
         addTabBtn.addEventListener('click', addCurrentTabToActiveWorkspace);
         workspaceList.addEventListener('click', handleWorkspaceListClick);
+        tabs.addEventListener('change', () => {
+            const selectedTab = tabs.selected;
+            if (selectedTab === 0) { // Workspaces
+                workspaceList.style.display = 'block';
+                tabList.style.display = 'none';
+            } else { // Tabs
+                workspaceList.style.display = 'none';
+                tabList.style.display = 'block';
+            }
+        });
 
         chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             if (request.action === 'refresh') {


### PR DESCRIPTION
The previous implementation used outdated and incorrect direct script imports for each Material Web Component, which likely caused rendering or functionality errors.

This commit refactors the `sidebar.html` to use the recommended `importmap` and `esm.run` CDN method for loading Material Web Components. This ensures all components and their dependencies are loaded correctly.

Key changes:
- Replaced individual component imports with a single import for `@material/web/all.js`.
- Added an `importmap` to resolve Material Web component paths.
- Included the necessary Google Fonts (Roboto and Material Symbols) for proper styling.
- Injected Material Design typescale styles for correct typography.
- Added a tabbed interface in `sidebar.html` to switch between 'Workspaces' and 'Tabs' views.
- Updated `sidebar.js` to handle the new tab switching logic.