### PR TITLE
The side panel path in `manifest.json` was pointing to `dist/sidebar.…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
     "service_worker": "background.js"
   },
   "side_panel": {
-    "default_path": "dist/sidebar.html"
+    "default_path": "sidebar.html"
   },
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self';"


### PR DESCRIPTION
…html`, but the `sidebar.html` file is located in the root directory. This caused an error when trying to load the extension. This commit corrects the path to `sidebar.html`, allowing the extension to load correctly.